### PR TITLE
Return a default value by get() when the corresponding value is not defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,9 @@ exports.set = function(key, value) {
   u.sync(file, config);
 };
 
-exports.get = function(key)  {
-  return u.search(config, key);
+exports.get = function(key, defaultValue)  {
+  const value = u.search(config, key);
+  return value === undefined ? defaultValue : value;
 };
 
 exports.keys = function(key) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -109,6 +109,13 @@ it('.set() and .get() an object', function(done) {
   done();
 });
 
+it('.get() a default value', function(done) {
+  m.chai.expect(config.get('foo', 'bar')).to.equals('bar');
+  m.chai.expect(config.get('foo', undefined)).to.be.an('undefined');
+  m.chai.expect(config.get('foo')).to.be.an('undefined');
+  done();
+});
+
 it('deep .set() and deep .get() an object', function(done) {
   config.set('foo.bar', {bar: true, baz: 42});
   var res = config.get('foo.bar');


### PR DESCRIPTION
Hi Bastien.

Please let me suggest you to merge this request, which allows to simplify the following code:
```
let volume = config.get('volume');
volume = volume === undefined ? 1 : volume;
```
to `let volume = config.get('volume', 1);`