### PR TITLE
check if electron app isReady() prior to registering for ready callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,14 +7,21 @@ const file = (electron.app || electron.remote.app).getPath('userData')+'/config.
 
 let config = {};
 
-
-(electron.app || electron.remote.app).on('ready', () => {
+let readConfig = () => {
   if(!u.exists(file)) {
     fs.writeFileSync(file, '{}');
   }
-
   config = JSON.parse(fs.readFileSync(file));
-});
+} 
+
+if (electron.remote.app.isReady()) {
+  readConfig();
+}
+else {
+  (electron.app || electron.remote.app).on('ready', () => {
+    readConfig();
+  });
+}
 
 
 exports.file = function() {


### PR DESCRIPTION
if electron.remote.app 'ready' signal is sent prior to this module being loaded, the config file will never be loaded.  isReady() can be checked at initialization to see if electron was already initialized. 