### PR TITLE
read config file after electron initialization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,9 +12,9 @@ let readConfig = () => {
     fs.writeFileSync(file, '{}');
   }
   config = JSON.parse(fs.readFileSync(file));
-} 
+}; 
 
-if (electron.remote.app.isReady()) {
+if (electron.remote app && electron.remote.app.isReady()) {
   readConfig();
 }
 else {

--- a/src/index.js
+++ b/src/index.js
@@ -7,14 +7,21 @@ const file = (electron.app || electron.remote.app).getPath('userData')+'/config.
 
 let config = {};
 
-
-(electron.app || electron.remote.app).on('ready', () => {
+let readConfig = () => {
   if(!u.exists(file)) {
     fs.writeFileSync(file, '{}');
   }
-
   config = JSON.parse(fs.readFileSync(file));
-});
+} 
+
+if (electron.remote.app.isReady()) {
+  readConfig();
+}
+else {
+  (electron.app || electron.remote.app).on('ready', () => {
+    readConfig();
+  });
+}
 
 
 exports.file = function() {


### PR DESCRIPTION
commit 802158e96c2253d4365af6a2ec7f0d0c0df23e13 loaded the config file on an electron ready event callback.  If electron-json-config was loaded after this event was sent by electron, the config file will never be loaded.  This commit checks to see if electron is already initialized prior to loading the config file.