### PR TITLE
Format JSON file contents to allow for easier editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ A `key` can be :
 - an array of string representing a multi level key  
   eg: `['foo', 'bar']`
 
+### ConfigOptions
+
+```ts
+type ConfigOptions = {
+  prettyJson?: {
+    enabled: boolean;
+    indentSize?: number;
+  };
+};
+```
+
+Options for creating and storing Config contents.
+Currently supports formatting the JSON file contents in a pretty, indented 
+format for easy readability or editability.
+
+`prettyJson.identSize` defaults to `2` if this option is `enabled`.
+
 
 ### Storable
 
@@ -72,7 +89,7 @@ interface Storable {
 ```
 
 
-### `factory(file?: string, key?: string): Conf`
+### `factory(file?: string, key?: string, options?: ConfigOptions): Conf`
 
 **Description:**  
 Create an instance of [Config] and returns it.  
@@ -99,13 +116,19 @@ factory('/data/test.json', 'test');
 // file: app.getPath('userData') + '/config.json'
 // key: 'test'
 factory(undefined, 'test');
+
+// file: app.getPath('userData') + '/config.json'
+// key: 'test'
+// JSON stored in readable, indented format (with default 2 space tab)
+factory(undefined, 'test', { prettyJson: { enabled: true }});
 ```
 
 **Parameters:**
-| Name    | Type     | Default                                    |
-| ------- | -------- | ------------------------------------------ |
-| `file?` | [string] | `app.getPath('userData') + '/config.json'` |
-| `key?`  | [string] | `key || file || 'userData'`                |
+| Name       | Type            | Default                                    |
+| ---------- | --------------- | ------------------------------------------ |
+| `file?`    | [string]        | `app.getPath('userData') + '/config.json'` |
+| `key?`     | [string]        | `key || file || 'userData'`                |
+| `options?` | [ConfigOptions] | `{ prettyJson: { enabled: false }}`        |
 
 **Returns:** void
 
@@ -114,12 +137,13 @@ factory(undefined, 'test');
 
 The config class is a set of wrappers and helpers providing access to configuration and file synchronization.
 
-#### `new Config(file: string, data: Storable): Config`
+#### `new Config(file: string, data: Storable, options?: ConfigOptions): Config`
 **Parameters:**
-| Name   | Type       |
-| ------ | ---------- |
-| `file` | [string]   |
-| `data` | [Storable] |
+| Name       | Type            |
+| ---------- | --------------- |
+| `file`     | [string]        |
+| `data`     | [Storable]      |
+| `options?` | [ConfigOptions] |
 
 **Returns:** [Config]
 
@@ -214,6 +238,7 @@ If `key` is provided, returns an array containing all sub keys in the key object
 
 
 [Key]: #key
+[ConfigOptions]: #configOptions
 [Storable]: #storable
 [Config]: #config
 [string]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test": "electron-mocha -r ts-node/register '**/*.spec.ts'",
     "test:coverage": "nyc npm run test",
     "test:docker": "xvfb-run --server-args=\"-screen 0 1024x780x24\" npm run test",
-    "build": "tsc"
+    "build": "tsc",
+    "prepare": "npm run build"
   },
   "license": "BSD-2-Clause",
   "devDependencies": {

--- a/src/Config.spec.ts
+++ b/src/Config.spec.ts
@@ -44,7 +44,7 @@ describe('Config.set', () => {
     it('syncs the file on call', () => {
         config.set('isSynced', 'sure');
         const content = readFileSync(tmpFile).toString();
-        expect(content).to.equals(JSON.stringify((config as any)._data));
+        expect(content).to.equals(JSON.stringify((config as any)._data, null, 2));
     });
 });
 
@@ -63,7 +63,7 @@ describe('Config.setBulk', () => {
     it('syncs the file on call', () => {
         config.set('isSynced', 'sure');
         const content = readFileSync(tmpFile).toString();
-        expect(content).to.equals(JSON.stringify((config as any)._data));
+        expect(content).to.equals(JSON.stringify((config as any)._data, null, 2));
     });
 });
 

--- a/src/Config.spec.ts
+++ b/src/Config.spec.ts
@@ -3,7 +3,7 @@ import { app } from 'electron';
 import { expect } from 'chai';
 import { join } from 'path';
 import { unlinkSync, readFileSync } from 'fs';
-import Config from './Config';
+import Config, { DEFAULT_CONFIG } from './Config';
 
 const tmpFile = join(app.getPath('temp'), 'test.json');
 
@@ -44,8 +44,28 @@ describe('Config.set', () => {
     it('syncs the file on call', () => {
         config.set('isSynced', 'sure');
         const content = readFileSync(tmpFile).toString();
-        expect(content).to.equals(JSON.stringify((config as any)._data, null, 2));
+        expect(content).to.equals(JSON.stringify((config as any)._data));
     });
+});
+
+describe('Config.set (with pretty JSON)', () => {
+  const config = new Config(tmpFile, {}, { prettyJson: { enabled: true }});
+
+  it('adds a value under a top level key', () => {
+      config.set('foo', 'bar');
+      expect((config as any)._data?.foo).to.equals('bar');
+  });
+
+  it('adds a value under a nested key', () => {
+      config.set('the.answer', 42);
+      expect((config as any)._data?.the?.answer).to.equals(42);
+  });
+
+  it('syncs the file on call', () => {
+      config.set('isSynced', 'sure');
+      const content = readFileSync(tmpFile).toString();
+      expect(content).to.equals(JSON.stringify((config as any)._data, null, 2));
+  });
 });
 
 describe('Config.setBulk', () => {
@@ -63,8 +83,27 @@ describe('Config.setBulk', () => {
     it('syncs the file on call', () => {
         config.set('isSynced', 'sure');
         const content = readFileSync(tmpFile).toString();
-        expect(content).to.equals(JSON.stringify((config as any)._data, null, 2));
+        expect(content).to.equals(JSON.stringify((config as any)._data));
     });
+});
+
+describe('Config.setBulk (with pretty JSON)', () => {
+  const config = new Config(tmpFile, {}, { prettyJson: { enabled: true }});
+
+  it('adds multiple values in a single call', () => {
+      config.setBulk({
+          'foo': 'bar',
+          'the.answer': 42,
+      });
+      expect((config as any)._data?.foo).to.equals('bar');
+      expect((config as any)._data?.the?.answer).to.equals(42);
+  });
+
+  it('syncs the file on call', () => {
+      config.set('isSynced', 'sure');
+      const content = readFileSync(tmpFile).toString();
+      expect(content).to.equals(JSON.stringify((config as any)._data, null, 2));
+  });
 });
 
 describe('Config.get', () => {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -20,6 +20,12 @@ function sync(
     return descriptor;
 }
 
+/**
+ * Options that can be passed to Config for writing and storing data
+ * 
+ * Currently supports pretty JSON format for storing indented, 
+ * multi-line in file
+ */
 export type ConfigOptions = {
     prettyJson?: {
         enabled: boolean;
@@ -27,6 +33,9 @@ export type ConfigOptions = {
     };
 };
 
+/**
+ * Default config, used for optional `options` args throughout
+ */
 export const DEFAULT_CONFIG = { 
     prettyJson: {
         enabled: false,

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -12,13 +12,26 @@ function sync(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     descriptor.value = function (this: any, ...args: Array<any>): any {
         const res = originalMethod.apply(this, args);
-        util.sync(this._file, this._data);
+        util.sync(this._file, this._data, this._options);
 
         return res;
     };
 
     return descriptor;
 }
+
+export type ConfigOptions = {
+    prettyJson?: {
+        enabled: boolean;
+        indentSize?: number;
+    };
+};
+
+export const DEFAULT_CONFIG = { 
+    prettyJson: {
+        enabled: false,
+    },
+};
 
 /**
  * A Key can be:
@@ -31,10 +44,16 @@ export type Key = string | Array<string>;
 export default class Config {
     private _file: string;
     private _data: Storable;
+    private _options: ConfigOptions;
 
-    public constructor(file: string, data: Storable) {
+    public constructor(
+        file: string, 
+        data: Storable, 
+        options: ConfigOptions = DEFAULT_CONFIG,
+    ) {
         this._file = file;
         this._data = data;
+        this._options = options;
     }
 
     public get file(): string {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -12,7 +12,7 @@ function sync(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     descriptor.value = function (this: any, ...args: Array<any>): any {
         const res = originalMethod.apply(this, args);
-        util.sync(this._file, this._data, this._options);
+        util.sync(this._file, this._data, this._options.prettyJson);
 
         return res;
     };
@@ -21,18 +21,22 @@ function sync(
 }
 
 /**
+ * Type to support configuration of pretty JSON when writing JSON file
+ */
+export type PrettyJSONConfig = {
+  enabled: boolean;
+  indentSize?: number;
+};
+
+/**
  * Options that can be passed to Config for writing and storing data
  * 
  * Currently supports pretty JSON format for storing indented, 
  * multi-line in file
  */
 export type ConfigOptions = {
-    prettyJson?: {
-        enabled: boolean;
-        indentSize?: number;
-    };
+   prettyJson?: PrettyJSONConfig;
 };
-
 /**
  * Default config, used for optional `options` args throughout
  */

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,7 +1,7 @@
 import { app } from 'electron';
 import { join } from 'path';
 import { read } from './utils';
-import Conf from './Config';
+import Conf, { ConfigOptions, DEFAULT_CONFIG } from './Config';
 
 const defaultFile = join(app.getPath('userData'), 'config.json');
 const defaultKey = 'userData';
@@ -9,7 +9,11 @@ const defaultKey = 'userData';
 const instances: Map<string, Conf> = new Map();
 
 
-export function factory(file?: string, key?: string): Conf {
+export function factory(
+    file?: string,
+    key?: string,
+    options: ConfigOptions = DEFAULT_CONFIG,
+): Conf {
     const actualKey = key || file || defaultKey;
 
     if (!instances.has(actualKey)) {
@@ -17,7 +21,7 @@ export function factory(file?: string, key?: string): Conf {
 
         instances.set(
             actualKey,
-            new Conf(actualFile, read(actualFile)),
+            new Conf(actualFile, read(actualFile), options),
         );
     }
 

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -51,7 +51,7 @@ describe('utils.sync', () => {
     
         const defaultIndent = 2;
     
-        utils.sync(path, data, { prettyJson: { enabled: true } });
+        utils.sync(path, data, { enabled: true });
     
         const content = readFileSync(path).toString();
         expect(content).to.equals(JSON.stringify(data, null, defaultIndent));
@@ -66,9 +66,7 @@ describe('utils.sync', () => {
     
         const indent = 4;
     
-        utils.sync(path, data, {
-          prettyJson: { enabled: true, indentSize: indent },
-        });
+        utils.sync(path, data, { enabled: true, indentSize: indent });
     
         const content = readFileSync(path).toString();
         expect(content).to.equals(JSON.stringify(data, null, indent));

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -38,7 +38,7 @@ describe('utils.sync', () => {
         utils.sync(path, data);
 
         const content = readFileSync(path).toString();
-        expect(content).to.equals(JSON.stringify(data));
+        expect(content).to.equals(JSON.stringify(data, null, 2));
     });
 });
 

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -28,6 +28,8 @@ function unlinkTmpFiles() {
 }
 
 describe('utils.sync', () => {
+    afterEach(unlinkTmpFiles);
+
     it('updates the file with given object', () => {
         const path = join(tmpDir, 'iexist');
         const data: Storable = {
@@ -38,7 +40,38 @@ describe('utils.sync', () => {
         utils.sync(path, data);
 
         const content = readFileSync(path).toString();
-        expect(content).to.equals(JSON.stringify(data, null, 2));
+        expect(content).to.equals(JSON.stringify(data));
+    });
+    it('updates the file with given object - pretty JSON (indent default)', () => {
+        const path = join(tmpDir, 'iexist');
+        const data: Storable = {
+          first: 'level',
+          deep: { nested: 'value' },
+        };
+    
+        const defaultIndent = 2;
+    
+        utils.sync(path, data, { prettyJson: { enabled: true } });
+    
+        const content = readFileSync(path).toString();
+        expect(content).to.equals(JSON.stringify(data, null, defaultIndent));
+    });
+  
+    it('updates the file with given object - pretty JSON (indent 4)', () => {
+        const path = join(tmpDir, 'iexist');
+        const data: Storable = {
+          first: 'level',
+          deep: { nested: 'value' },
+        };
+    
+        const indent = 4;
+    
+        utils.sync(path, data, {
+          prettyJson: { enabled: true, indentSize: indent },
+        });
+    
+        const content = readFileSync(path).toString();
+        expect(content).to.equals(JSON.stringify(data, null, indent));
     });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,18 +1,15 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { Buffer } from 'buffer';
 import Storable from "./Storable";
-import { ConfigOptions, DEFAULT_CONFIG, Key } from './Config';
+import { DEFAULT_CONFIG, Key, PrettyJSONConfig } from './Config';
 
 export function sync(
   file: string,
   data: Record<string, unknown>,
-  options: ConfigOptions = DEFAULT_CONFIG,
+  options: PrettyJSONConfig = DEFAULT_CONFIG['prettyJson'],
 ): void {
-  if (options.prettyJson && options.prettyJson.enabled) {
-    writeFileSync(
-      file,
-      JSON.stringify(data, null, options.prettyJson.indentSize || 2),
-    );
+  if (options?.enabled) {
+    writeFileSync(file, JSON.stringify(data, null, options.indentSize || 2));
   } else {
     writeFileSync(file, JSON.stringify(data));
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,14 +1,14 @@
-import { readFileSync, writeFileSync } from 'fs';
-import { Buffer } from 'buffer';
+import { readFileSync, writeFileSync } from "fs";
+import { Buffer } from "buffer";
 import Storable from "./Storable";
-import { DEFAULT_CONFIG, Key, PrettyJSONConfig } from './Config';
+import { DEFAULT_CONFIG, Key, PrettyJSONConfig } from "./Config";
 
 export function sync(
   file: string,
   data: Record<string, unknown>,
-  options: PrettyJSONConfig = DEFAULT_CONFIG['prettyJson'],
+  options: PrettyJSONConfig = DEFAULT_CONFIG["prettyJson"],
 ): void {
-  if (options?.enabled) {
+  if (options.enabled) {
     writeFileSync(file, JSON.stringify(data, null, options.indentSize || 2));
   } else {
     writeFileSync(file, JSON.stringify(data));
@@ -21,12 +21,12 @@ export function read(file: string): Storable {
     // See: https://nodejs.org/api/fs.html#fs_fs_readfile_path_options_callback
     const data = readFileSync(file) as Buffer;
     return JSON.parse(data.toString());
-  } catch(err) {
+  } catch (err) {
     if (
       err instanceof Error &&
-      (err as NodeJS.ErrnoException).code === 'ENOENT'
+      (err as NodeJS.ErrnoException).code === "ENOENT"
     ) {
-      writeFileSync(file, '{}');
+      writeFileSync(file, "{}");
       return {};
     }
     throw err;
@@ -38,11 +38,11 @@ export function pathiffy(key: Key): Array<string> {
     return key;
   }
 
-  return key.split('.');
+  return key.split(".");
 }
 
 export function search<T>(data: Storable, key: Key): T | undefined {
-  const path = pathiffy(key)
+  const path = pathiffy(key);
 
   for (let i = 0; i < path.length; i++) {
     if (data[path[i]] === undefined) {
@@ -54,11 +54,7 @@ export function search<T>(data: Storable, key: Key): T | undefined {
   return data as T;
 }
 
-export function set<T>(
-  data: Storable,
-  key: Key,
-  value: Storable | T,
-): void {
+export function set<T>(data: Storable, key: Key, value: Storable | T): void {
   const path = pathiffy(key);
   let i;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,21 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { Buffer } from 'buffer';
 import Storable from "./Storable";
-import { Key } from './Config';
+import { ConfigOptions, DEFAULT_CONFIG, Key } from './Config';
 
-export function sync(file: string, data: Record<string, unknown>): void {
-  writeFileSync(file, JSON.stringify(data, null, 2));
+export function sync(
+  file: string,
+  data: Record<string, unknown>,
+  options: ConfigOptions = DEFAULT_CONFIG,
+): void {
+  if (options.prettyJson && options.prettyJson.enabled) {
+    writeFileSync(
+      file,
+      JSON.stringify(data, null, options.prettyJson.indentSize || 2),
+    );
+  } else {
+    writeFileSync(file, JSON.stringify(data));
+  }
 }
 
 export function read(file: string): Storable {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import Storable from "./Storable";
 import { Key } from './Config';
 
 export function sync(file: string, data: Record<string, unknown>): void {
-  writeFileSync(file, JSON.stringify(data));
+  writeFileSync(file, JSON.stringify(data, null, 2));
 }
 
 export function read(file: string): Storable {


### PR DESCRIPTION
Currently the JSON file contents are written on a single line. If this external `config.json` needs to be edited externally, it is very hard to do so. This change uses a 2 space tabbed format when `utils.sync` is called to ensure the JSON is formatted in a more friendly, readable & editable format in the file.